### PR TITLE
feat(email): EmailContent supports htmlMessage alternative

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -483,10 +483,12 @@ object email extends JvmOnlyModule {
   def moduleName = "email"
   def description = "IW Support Email Library"
   def moduleDeps = Seq(core.jvm)
-  
+
   def mvnDeps = super.mvnDeps() ++ Dependencies.zioCore ++ Dependencies.zioConfig ++ Seq(
     mvn"org.apache.commons:commons-email:1.5"
   ) ++ Dependencies.withSilencer(Seq())(using scalaVersion())
+
+  object test extends BaseTests
 }
 
 // Codecs module - pure shared sources

--- a/email/src/main/scala/works/iterative/service/email/EmailNotificationService.scala
+++ b/email/src/main/scala/works/iterative/service/email/EmailNotificationService.scala
@@ -7,6 +7,7 @@ import works.iterative.core.Email
 case class EmailContent(
     subject: String,
     message: String,
+    htmlMessage: Option[String] = None,
     attachments: Attachment*
 )
 
@@ -34,7 +35,7 @@ trait EmailNotificationService:
         content: String,
         attachments: Attachment*
     )(to: Email*): Op[Unit] =
-        sendEmail(EmailContent(subject, content, attachments*))(to*)
+        sendEmail(EmailContent(subject, content, None, attachments*))(to*)
 
     def sendEmail(content: EmailContent)(to: Email*): Op[Unit]
 end EmailNotificationService

--- a/email/src/main/scala/works/iterative/service/email/impl/apache/CommonsEmailNotificationService.scala
+++ b/email/src/main/scala/works/iterative/service/email/impl/apache/CommonsEmailNotificationService.scala
@@ -1,8 +1,11 @@
+// PURPOSE: Apache Commons Email backed implementation of EmailNotificationService.
+// PURPOSE: Selects MultiPartEmail or HtmlEmail depending on whether EmailContent carries an HTML alternative.
+
 package works.iterative.service.email
 package impl.apache
 
 import zio.*
-import org.apache.commons.mail.MultiPartEmail
+import org.apache.commons.mail.{HtmlEmail, MultiPartEmail}
 import javax.mail.util.ByteArrayDataSource
 import works.iterative.core.Email
 
@@ -12,9 +15,10 @@ class CommonsEmailNotificationService(config: SMTPConfig)
     import EmailNotificationService.Error.*
 
     override def sendEmail(content: EmailContent)(to: Email*): Op[Unit] =
-        val email = new MultiPartEmail()
-
         for
+            email <- ZIO
+                .attempt(buildEmail(content))
+                .mapError(InvalidRequest(_))
             _ <- ZIO
                 .attempt {
                     email.setHostName(config.smtpHost)
@@ -28,15 +32,6 @@ class CommonsEmailNotificationService(config: SMTPConfig)
                 .mapError(ConfigurationError(_))
             _ <- ZIO
                 .attempt {
-                    email.setSubject(content.subject)
-                    email.setMsg(content.message)
-                    content.attachments.foreach { a =>
-                        email.attach(
-                            ByteArrayDataSource(a.content, a.mimeType),
-                            a.filename,
-                            a.description
-                        )
-                    }
                     config.smtpTestRecipient match
                         case Some(recip) => email.addTo(recip)
                         case None        => to.map[String](_.value).foreach(email.addTo)
@@ -48,6 +43,32 @@ class CommonsEmailNotificationService(config: SMTPConfig)
         yield ()
         end for
     end sendEmail
+
+    /** Build an Apache Commons email instance carrying the configured subject, body, optional HTML
+      * alternative, and attachments. Returns an `HtmlEmail` (a `MultiPartEmail` subclass) when
+      * `content.htmlMessage` is defined, otherwise a plain `MultiPartEmail`.
+      */
+    def buildEmail(content: EmailContent): MultiPartEmail =
+        val email = content.htmlMessage match
+            case Some(html) =>
+                val htmlEmail = new HtmlEmail()
+                htmlEmail.setTextMsg(content.message)
+                htmlEmail.setHtmlMsg(html)
+                htmlEmail
+            case None =>
+                val plain = new MultiPartEmail()
+                plain.setMsg(content.message)
+                plain
+        email.setSubject(content.subject)
+        content.attachments.foreach { a =>
+            email.attach(
+                ByteArrayDataSource(a.content, a.mimeType),
+                a.filename,
+                a.description
+            )
+        }
+        email
+    end buildEmail
 end CommonsEmailNotificationService
 
 object CommonsEmailNotificationService:

--- a/email/src/test/scala/works/iterative/service/email/impl/apache/CommonsEmailNotificationServiceSpec.scala
+++ b/email/src/test/scala/works/iterative/service/email/impl/apache/CommonsEmailNotificationServiceSpec.scala
@@ -1,0 +1,76 @@
+// PURPOSE: Unit tests for CommonsEmailNotificationService email construction.
+// PURPOSE: Verifies HtmlEmail vs MultiPartEmail selection based on EmailContent.htmlMessage.
+
+package works.iterative.service.email
+package impl.apache
+
+import zio.test.*
+
+import org.apache.commons.mail.HtmlEmail
+
+object CommonsEmailNotificationServiceSpec extends ZIOSpecDefault:
+
+    private val testConfig = SMTPConfig(
+        smtpHost = "localhost",
+        smtpPort = 25,
+        smtpUsername = None,
+        smtpPassword = None,
+        smtpSender = "from@example.com",
+        smtpSenderName = Some("Test Sender"),
+        smtpTestRecipient = None
+    )
+
+    private def service: CommonsEmailNotificationService =
+        new CommonsEmailNotificationService(testConfig)
+
+    private val sampleSubject = "Hello"
+    private val sampleText = "Plain body"
+    private val sampleHtml = "<p>HTML body</p>"
+
+    def spec = suite("CommonsEmailNotificationService.buildEmail")(
+        test("htmlMessage = None produces a MultiPartEmail (not HtmlEmail) with subject and text body") {
+            val content = EmailContent(sampleSubject, sampleText)
+            val email = service.buildEmail(content)
+            assertTrue(
+                !email.isInstanceOf[HtmlEmail],
+                email.getSubject == sampleSubject
+            )
+        },
+        test("htmlMessage = Some produces an HtmlEmail carrying the html body") {
+            val content = EmailContent(
+                sampleSubject,
+                sampleText,
+                htmlMessage = Some(sampleHtml)
+            )
+            val email = service.buildEmail(content)
+            val htmlField =
+                val f = classOf[HtmlEmail].getDeclaredField("html")
+                f.setAccessible(true)
+                f.get(email).asInstanceOf[String]
+            assertTrue(
+                email.isInstanceOf[HtmlEmail],
+                email.getSubject == sampleSubject,
+                htmlField == sampleHtml
+            )
+        },
+        test("htmlMessage = Some preserves attachments via HtmlEmail path") {
+            val attachment = Attachment(
+                filename = "note.txt",
+                mimeType = "text/plain",
+                content = "hello".getBytes("UTF-8")
+            )
+            val content = EmailContent(
+                sampleSubject,
+                sampleText,
+                Some(sampleHtml),
+                attachment
+            )
+            val email = service.buildEmail(content)
+            assertTrue(email.isInstanceOf[HtmlEmail])
+        },
+        test("EmailContent.htmlMessage defaults to None for existing call sites") {
+            val content = EmailContent(sampleSubject, sampleText)
+            assertTrue(content.htmlMessage == None)
+        }
+    )
+end CommonsEmailNotificationServiceSpec


### PR DESCRIPTION
## Summary
- `EmailContent` gains a trailing-default `htmlMessage: Option[String] = None`. When set, `CommonsEmailNotificationService` builds an `HtmlEmail` (multipart text+html alternative) instead of a plain `MultiPartEmail`; text-only callers are unchanged.
- Adds the first unit test suite for the email module, covering the `HtmlEmail` vs `MultiPartEmail` branch selection.
- Required by MEDH-156 Phase 8 (medeca dispatch template editing UI): automated dispatch templates need to send multipart text+html bodies.

## Test plan
- [x] `./mill __.test` (pre-push hook) — all 1692 tests passed locally
- [ ] CI green on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)