### PR TITLE
fix(pac4j): validate Pac4jSecurityConfig and stop composing OIDC URLs from baseUri

### DIFF
--- a/docs/HTTP_SERVER_GUIDE.md
+++ b/docs/HTTP_SERVER_GUIDE.md
@@ -420,12 +420,17 @@ HTTP4s middleware for Pac4j-based authentication:
 ```scala
 // Source: server/http/src/main/scala/.../impl/pac4j/Pac4jHttpSecurity.scala
 class Pac4jHttpSecurity[F[_] <: AnyRef: Sync](
-    baseUri: BaseUri,
     config: Pac4jSecurityConfig,
     pac4jConfig: Config,        // Pac4j Config object
     dispatcher: Dispatcher[F]
 ) extends HttpSecurity
 ```
+
+> **Breaking change in 0.1.16.** The `baseUri: BaseUri` parameter has been removed from
+> `Pac4jHttpSecurity` and `Pac4jConfigFactory`. Cookie `Path` and the OIDC `redirect_uri` are now
+> derived from `Pac4jSecurityConfig` (see [Pac4jSecurityConfig](#pac4jsecurityconfig) below).
+> In 0.1.15 and earlier, passing the full URL as `baseUri = BaseUri(urlBase)` produced a
+> double-prefixed `redirect_uri` and a malformed cookie `Path` attribute.
 
 Key methods:
 
@@ -499,15 +504,21 @@ class AppModuleRegistry(
 ```scala
 // Source: server/http/src/main/scala/.../impl/pac4j/Pac4jSecurityConfig.scala
 case class Pac4jSecurityConfig(
-    urlBase: String,                        // e.g., "https://example.com"
-    callbackBase: String,                   // e.g., "/security"
+    urlBase: String,                        // absolute origin, e.g. "https://example.com"
+    callbackBase: String,                   // path prefix for auth routes, e.g. "/auth/oidc"
     defaultUrl: Option[String],             // redirect after login
     logoutUrl: Option[String],              // redirect after logout
     logoutUrlPattern: Option[String],
     sessionSecret: String,
+    cookiePath: Option[String],             // session/CSRF cookie Path; default "/"
     client: OidcClientConfig,               // primary OIDC provider
     clients: Map[String, OidcClientConfig]  // additional named providers
-)
+):
+    /** Absolute redirect_uri advertised to the IdP. Must appear verbatim in Auth0's allowed list. */
+    def callbackUrl: String = s"$urlBase$callbackBase/callback"
+
+    /** Resolved Path attribute for session and CSRF cookies. */
+    def resolvedCookiePath: String = cookiePath.getOrElse("/")
 
 case class OidcClientConfig(
     clientId: String,
@@ -515,6 +526,42 @@ case class OidcClientConfig(
     discoveryURI: String
 )
 ```
+
+**Validation contract — enforced at config load time by `Pac4jSecurityConfig.config` via `mapOrFail`.**
+Any value that violates these rules surfaces as `zio.Config.Error.InvalidData` at startup, so the
+server never boots with a configuration that would produce a malformed OIDC URL.
+
+| Field          | Rule                                                                                |
+|----------------|--------------------------------------------------------------------------------------|
+| `urlbase`      | matches `^https?://[^/?#]+$` — scheme + host (+ optional port). No path/query/fragment, no trailing `/`. |
+| `callbackbase` | empty, or matches `^/[^/?#]+(/[^/?#]+)*$` — leading `/`, no trailing `/`, no scheme. |
+| `cookiepath`   | when set, matches `^/[^?#]*$`.                                                       |
+| `callbackUrl`  | the composed `urlBase + callbackBase + "/callback"` must parse as an absolute URI with a host. |
+
+**Composition example (Auth0 BFF mounted at origin root):**
+
+```
+urlBase      = "https://app.example.com"
+callbackBase = "/auth/oidc"
+→ callbackUrl = "https://app.example.com/auth/oidc/callback"
+→ resolvedCookiePath = "/"
+```
+
+Auth0's application "Allowed Callback URLs" must contain `"https://app.example.com/auth/oidc/callback"` exactly. `Pac4jConfigFactory.build()` reads `callbackUrl` directly when constructing the `Clients` registry — no further string surgery is performed.
+
+**Env-var mapping.** The ZIO Config descriptor uses lowercase keys; the default `ConfigProvider.envProvider` uppercases them and joins nested fields with `_`:
+
+| Config key                       | Env var                          |
+|----------------------------------|----------------------------------|
+| `security.urlbase`               | `SECURITY_URLBASE`               |
+| `security.callbackbase`          | `SECURITY_CALLBACKBASE`          |
+| `security.cookiepath`            | `SECURITY_COOKIEPATH` (optional) |
+| `security.sessionsecret`         | `SECURITY_SESSIONSECRET`         |
+| `security.client.id`             | `SECURITY_CLIENT_ID`             |
+| `security.client.secret`         | `SECURITY_CLIENT_SECRET`         |
+| `security.client.discoveryuri`   | `SECURITY_CLIENT_DISCOVERYURI`   |
+
+Note the OIDC client subfields are `id` / `secret` / `discoveryuri` — NOT `clientId` / `clientSecret` / `discoveryURI`. The case-class field names are camelCase but the descriptor keys (and env vars) are flat lowercase.
 
 ### Approach 2: Reverse Proxy Headers
 

--- a/server/http/src/main/scala/works/iterative/server/http/impl/pac4j/Pac4jConfigFactory.scala
+++ b/server/http/src/main/scala/works/iterative/server/http/impl/pac4j/Pac4jConfigFactory.scala
@@ -1,3 +1,5 @@
+// PURPOSE: Builds the Pac4j Config (clients + session store) from a validated Pac4jSecurityConfig.
+// PURPOSE: Composes the OIDC redirect_uri via Pac4jSecurityConfig.callbackUrl — no string surgery here.
 package works.iterative.server.http
 package impl.pac4j
 
@@ -7,7 +9,6 @@ import org.pac4j.oidc.config.OidcConfiguration
 import org.pac4j.http4s.DefaultHttpActionAdapter
 import cats.effect.Sync
 import org.pac4j.core.client.Clients
-import works.iterative.tapir.BaseUri
 import org.pac4j.core.authorization.generator.AuthorizationGenerator
 import org.pac4j.core.profile.UserProfile
 import java.util.Optional
@@ -20,8 +21,17 @@ import org.pac4j.http4s.Http4sGenericSessionStore
 import org.pac4j.http4s.CacheSessionRepository
 import cats.effect.std.Dispatcher
 
+/** Builds Pac4j's `Config` (clients + session store) from a validated [[Pac4jSecurityConfig]].
+  *
+  * The OIDC client's callback URL is taken verbatim from [[Pac4jSecurityConfig.callbackUrl]];
+  * the cookie `Path` comes from [[Pac4jSecurityConfig.resolvedCookiePath]]. Both values are
+  * validated at config-load time, so this class performs no further URL surgery.
+  *
+  * **Breaking change vs. iw-support 0.1.15:** the `baseUri: BaseUri` constructor parameter has
+  * been removed. Pass [[Pac4jSecurityConfig]] alone — the callback URL is derived from
+  * `urlBase + callbackBase` and the cookie path from `cookiePath`.
+  */
 class Pac4jConfigFactory[F[_] <: AnyRef: Sync](
-    baseUri: BaseUri,
     pac4jConfig: Pac4jSecurityConfig,
     dispatcher: Dispatcher[F],
     authorizationGenerator: AuthorizationGenerator =
@@ -31,8 +41,8 @@ class Pac4jConfigFactory[F[_] <: AnyRef: Sync](
         new CacheSessionRepository[F],
         dispatcher
     )(
-        path = Some(baseUri.value.fold("/")(_.toString)),
-        secure = pac4jConfig.callbackBase.startsWith("https://"),
+        path = Some(pac4jConfig.resolvedCookiePath),
+        secure = pac4jConfig.urlBase.startsWith("https://"),
         httpOnly = true,
         sameSite = Some(SameSite.Lax)
     )
@@ -40,13 +50,12 @@ class Pac4jConfigFactory[F[_] <: AnyRef: Sync](
     @nowarn("cat=deprecation")
     override def build(parameters: AnyRef*): Config =
         val clients = Clients(
-            s"${pac4jConfig.urlBase}${baseUri.value.fold("/")(_.toString)}${pac4jConfig.callbackBase}/callback",
+            pac4jConfig.callbackUrl,
             (oidcClient(pac4jConfig.client) :: (pac4jConfig.clients.map: (name, conf) =>
                 val client = oidcClient(conf)
                 client.setName(name)
                 client
             ).toList).asJava
-            // new AnonymousClient
         )
         val config = new Config(clients)
         config.setHttpActionAdapter(DefaultHttpActionAdapter[F]())
@@ -64,7 +73,6 @@ class Pac4jConfigFactory[F[_] <: AnyRef: Sync](
         oidcConfiguration.setClientAuthenticationMethod(
             ClientAuthenticationMethod.CLIENT_SECRET_BASIC
         )
-        // oidcConfiguration.addCustomParam("prompt", "consent")
         val oidcClient = new OidcClient(oidcConfiguration)
         oidcClient.setAuthorizationGenerator(authorizationGenerator)
         oidcClient

--- a/server/http/src/main/scala/works/iterative/server/http/impl/pac4j/Pac4jHttpSecurity.scala
+++ b/server/http/src/main/scala/works/iterative/server/http/impl/pac4j/Pac4jHttpSecurity.scala
@@ -1,3 +1,5 @@
+// PURPOSE: http4s middleware mounting Pac4j callback/logout routes and securing authenticated routes.
+// PURPOSE: Cookie Path comes from Pac4jSecurityConfig.resolvedCookiePath; no BaseUri parameter.
 package works.iterative.server.http
 package impl.pac4j
 
@@ -11,7 +13,6 @@ import org.pac4j.core.engine.DefaultSecurityLogic
 import scala.concurrent.duration.given
 import org.http4s.dsl.Http4sDsl
 import org.http4s.server.Router
-import works.iterative.tapir.BaseUri
 import org.pac4j.core.engine.SecurityGrantedAccessAdapter
 import org.http4s.AuthedRoutes
 import cats.effect.std.Dispatcher
@@ -19,8 +20,13 @@ import cats.effect.Sync
 
 trait HttpSecurity
 
+/** http4s middleware wrapping Pac4j's callback / logout routes and the security filter.
+  *
+  * **Breaking change vs. iw-support 0.1.15:** the `baseUri: BaseUri` constructor parameter has
+  * been removed. The cookie `Path` attribute now comes from
+  * [[Pac4jSecurityConfig.resolvedCookiePath]] (defaulting to `"/"`).
+  */
 class Pac4jHttpSecurity[F[_] <: AnyRef: Sync](
-    baseUri: BaseUri,
     config: Pac4jSecurityConfig,
     pac4jConfig: Config,
     dispatcher: Dispatcher[F]
@@ -34,7 +40,7 @@ class Pac4jHttpSecurity[F[_] <: AnyRef: Sync](
 
     private val sessionConfig = SessionConfig(
         cookieName = "session",
-        mkCookie = ResponseCookie(_, _, path = Some(baseUri.value.fold("/")(_.toString))),
+        mkCookie = ResponseCookie(_, _, path = Some(config.resolvedCookiePath)),
         secret = config.sessionSecret.getBytes.to(List),
         maxAge = 5.minutes
     )

--- a/server/http/src/main/scala/works/iterative/server/http/impl/pac4j/Pac4jSecurityConfig.scala
+++ b/server/http/src/main/scala/works/iterative/server/http/impl/pac4j/Pac4jSecurityConfig.scala
@@ -1,14 +1,39 @@
+// PURPOSE: Validated configuration for Pac4j-based OIDC authentication.
+// PURPOSE: Composes the OIDC callback URL and cookie path; fails at config-load on misuse.
 package works.iterative.server.http
 package impl.pac4j
 
 import zio.*
 
+/** Configuration for a single OIDC client. */
 case class OidcClientConfig(
     clientId: String,
     clientSecret: String,
     discoveryURI: String
 )
 
+/** Configuration for the Pac4j security middleware.
+  *
+  * Field contract — all values are validated by [[Pac4jSecurityConfig.config]] at load time:
+  *
+  *   - `urlBase`: absolute origin of the BFF as the browser sees it, e.g. `"http://localhost:8090"`.
+  *     Must be scheme + host (+ optional port) with **no** path, query, fragment, or trailing slash.
+  *   - `callbackBase`: path prefix where the auth routes are mounted, e.g. `"/auth/oidc"`. Must be
+  *     empty (auth at origin root) or start with `/` and **not** end with `/`. No scheme/host. The
+  *     OIDC callback URL is composed as [[callbackUrl]] = `urlBase + callbackBase + "/callback"`.
+  *   - `cookiePath`: cookie `Path` attribute for the session and CSRF cookies. Defaults to `"/"`.
+  *     Must start with `/`.
+  *   - `sessionSecret`: HMAC secret used to encrypt session cookies. Generate with
+  *     `openssl rand -hex 32`.
+  *   - `defaultUrl` / `logoutUrl` / `logoutUrlPattern`: optional overrides for post-login,
+  *     post-logout, and logout-URL allowlist patterns.
+  *   - `client` / `clients`: OIDC client configuration. `client` is the primary; `clients` is a
+  *     named map for additional clients.
+  *
+  * The [[Pac4jSecurityConfig.config]] descriptor enforces these rules and rejects misconfigured
+  * input with [[zio.Config.Error.InvalidData]] at startup, so a malformed URL never reaches the
+  * IdP.
+  */
 case class Pac4jSecurityConfig(
     urlBase: String,
     callbackBase: String,
@@ -16,27 +41,107 @@ case class Pac4jSecurityConfig(
     logoutUrl: Option[String],
     logoutUrlPattern: Option[String],
     sessionSecret: String,
+    cookiePath: Option[String],
     client: OidcClientConfig,
     clients: Map[String, OidcClientConfig]
-)
+):
+    /** Absolute callback URL the OIDC client advertises to the IdP as `redirect_uri`.
+      *
+      * The Auth0 application's "Allowed Callback URLs" list must contain this exact value.
+      */
+    def callbackUrl: String = s"$urlBase$callbackBase/callback"
+
+    /** Resolved `Path` attribute for session and CSRF cookies. */
+    def resolvedCookiePath: String = cookiePath.getOrElse("/")
+end Pac4jSecurityConfig
 
 object Pac4jSecurityConfig:
+
+    /** scheme + host (+ optional port). No path, query, fragment, or trailing slash. */
+    private val UrlBaseRe = """^https?://[^/?#]+$""".r
+
+    /** Empty, or `/`-prefixed path with no trailing slash, no scheme, no query/fragment. */
+    private val CallbackBaseRe = """^$|^/[^/?#]+(?:/[^/?#]+)*$""".r
+
+    /** Path starting with `/`, no query/fragment. */
+    private val CookiePathRe = """^/[^?#]*$""".r
+
     import Config.*
+
     val oidcConfig: Config[OidcClientConfig] =
-        (string("id") ++ string("secret") ++ string(
-            "discoveryuri"
-        )).map(OidcClientConfig.apply)
-    end oidcConfig
+        (string("id") ++ string("secret") ++ string("discoveryuri"))
+            .map(OidcClientConfig.apply)
 
     given config: Config[Pac4jSecurityConfig] =
         (
-            string("urlbase") ++ string("callbackbase") ++ string("defaulturl").optional ++ string(
-                "logouturl"
-            ).optional ++ string("logouturlpattern").optional ++ string(
-                "sessionsecret"
-            ) ++ oidcConfig.nested("client") ++ Config.table(
-                oidcConfig
-            ).withDefault(Map.empty).nested("clients")
-        ).nested("security").map(Pac4jSecurityConfig.apply)
+            string("urlbase") ++
+                string("callbackbase") ++
+                string("defaulturl").optional ++
+                string("logouturl").optional ++
+                string("logouturlpattern").optional ++
+                string("sessionsecret") ++
+                string("cookiepath").optional ++
+                oidcConfig.nested("client") ++
+                Config.table(oidcConfig).withDefault(Map.empty).nested("clients")
+        ).nested("security").map(Pac4jSecurityConfig.apply).mapOrFail(validate)
     end config
+
+    /** Validates the composed config and surfaces clear [[Config.Error.InvalidData]] on misuse. */
+    private[pac4j] def validate(
+        cfg: Pac4jSecurityConfig
+    ): Either[Config.Error, Pac4jSecurityConfig] =
+        for
+            _ <- ensureMatches(
+                Chunk("security", "urlbase"),
+                cfg.urlBase,
+                UrlBaseRe,
+                s"must be an absolute origin (scheme://host[:port]) with no path, query, fragment, or trailing '/', got: '${cfg.urlBase}'"
+            )
+            _ <- ensureMatches(
+                Chunk("security", "callbackbase"),
+                cfg.callbackBase,
+                CallbackBaseRe,
+                s"must be empty or start with '/' (no trailing '/', no scheme, no query/fragment), got: '${cfg.callbackBase}'"
+            )
+            _ <- cfg.cookiePath match
+                case Some(p) =>
+                    ensureMatches(
+                        Chunk("security", "cookiepath"),
+                        p,
+                        CookiePathRe,
+                        s"must be a path starting with '/' (no scheme, no query/fragment), got: '$p'"
+                    )
+                case None => Right(())
+            _ <- ensureParses(Chunk("security"), cfg.callbackUrl)
+        yield cfg
+
+    private def ensureMatches(
+        path: Chunk[String],
+        value: String,
+        re: scala.util.matching.Regex,
+        message: String
+    ): Either[Config.Error, Unit] =
+        if re.matches(value) then Right(())
+        else Left(Config.Error.InvalidData(path, message))
+
+    /** Belt-and-suspenders: composed URL must parse as an absolute, host-bearing URI. */
+    private def ensureParses(
+        path: Chunk[String],
+        composed: String
+    ): Either[Config.Error, Unit] =
+        try
+            val uri = java.net.URI.create(composed)
+            if uri.isAbsolute && uri.getHost != null && uri.getRawSchemeSpecificPart != null
+            then Right(())
+            else
+                Left(Config.Error.InvalidData(
+                    path,
+                    s"composed callback URL is malformed (not absolute, no host, or empty): '$composed'"
+                ))
+        catch
+            case e: IllegalArgumentException =>
+                Left(Config.Error.InvalidData(
+                    path,
+                    s"composed callback URL fails to parse: '$composed' — ${e.getMessage}"
+                ))
 end Pac4jSecurityConfig

--- a/server/http/src/test/scala/works/iterative/server/http/impl/pac4j/Pac4jSecurityConfigSpec.scala
+++ b/server/http/src/test/scala/works/iterative/server/http/impl/pac4j/Pac4jSecurityConfigSpec.scala
@@ -1,0 +1,133 @@
+// PURPOSE: ZIO Test spec for Pac4jSecurityConfig validation and URL composition.
+// PURPOSE: Locks the URL-composition contract so the redirect_uri can never be malformed again.
+package works.iterative.server.http
+package impl.pac4j
+
+import zio.*
+import zio.test.*
+
+object Pac4jSecurityConfigSpec extends ZIOSpecDefault:
+
+    private val validBase: Map[String, String] = Map(
+        "security.urlbase" -> "http://localhost:8090",
+        "security.callbackbase" -> "/auth/oidc",
+        "security.sessionsecret" -> "0123456789abcdef0123456789abcdef",
+        "security.client.id" -> "cid",
+        "security.client.secret" -> "csec",
+        "security.client.discoveryuri" -> "https://example.test/.well-known/openid-configuration"
+    )
+
+    private def load(
+        map: Map[String, String]
+    ): ZIO[Any, Config.Error, Pac4jSecurityConfig] =
+        ConfigProvider.fromMap(map).load(Pac4jSecurityConfig.config)
+
+    private def assertInvalidAt(
+        result: Exit[Config.Error, Pac4jSecurityConfig],
+        pathSegment: String,
+        messageHint: String
+    ): TestResult =
+        val matched = result match
+            case Exit.Failure(cause) =>
+                cause.failures.exists:
+                    case Config.Error.InvalidData(path, msg) =>
+                        path.contains(pathSegment) && msg.contains(messageHint)
+                    case _ => false
+            case _ => false
+        assertTrue(matched)
+
+    def spec = suite("Pac4jSecurityConfig")(
+        test("loads a well-formed config and exposes composed callbackUrl") {
+            for cfg <- load(validBase)
+            yield assertTrue(
+                cfg.callbackUrl == "http://localhost:8090/auth/oidc/callback",
+                cfg.resolvedCookiePath == "/",
+                cfg.urlBase == "http://localhost:8090",
+                cfg.callbackBase == "/auth/oidc",
+                cfg.client.clientId == "cid"
+            )
+        },
+        test("accepts empty callbackbase (auth routes at origin root)") {
+            for cfg <- load(validBase + ("security.callbackbase" -> ""))
+            yield assertTrue(
+                cfg.callbackUrl == "http://localhost:8090/callback"
+            )
+        },
+        test("accepts explicit cookiepath") {
+            for cfg <- load(validBase + ("security.cookiepath" -> "/admin"))
+            yield assertTrue(cfg.resolvedCookiePath == "/admin")
+        },
+        test("rejects urlbase with trailing slash") {
+            for r <- load(validBase + ("security.urlbase" -> "http://localhost:8090/")).exit
+            yield assertInvalidAt(r, "urlbase", "absolute origin")
+        },
+        test("rejects urlbase that includes a path") {
+            for r <- load(validBase + ("security.urlbase" -> "http://localhost:8090/app")).exit
+            yield assertInvalidAt(r, "urlbase", "absolute origin")
+        },
+        test("rejects urlbase without scheme") {
+            for r <- load(validBase + ("security.urlbase" -> "localhost:8090")).exit
+            yield assertInvalidAt(r, "urlbase", "absolute origin")
+        },
+        test("rejects callbackbase missing leading slash") {
+            for r <- load(validBase + ("security.callbackbase" -> "auth/oidc")).exit
+            yield assertInvalidAt(r, "callbackbase", "start with '/'")
+        },
+        test("rejects callbackbase with trailing slash") {
+            for r <- load(validBase + ("security.callbackbase" -> "/auth/oidc/")).exit
+            yield assertInvalidAt(r, "callbackbase", "no trailing")
+        },
+        test("rejects callbackbase containing scheme") {
+            for r <- load(
+                validBase + ("security.callbackbase" -> "http://other/auth")
+            ).exit
+            yield assertInvalidAt(r, "callbackbase", "no scheme")
+        },
+        test("rejects bare '/' callbackbase (would compose to double slash)") {
+            for r <- load(validBase + ("security.callbackbase" -> "/")).exit
+            yield assertInvalidAt(r, "callbackbase", "no trailing")
+        },
+        test("rejects cookiepath missing leading slash") {
+            for r <- load(validBase + ("security.cookiepath" -> "admin")).exit
+            yield assertInvalidAt(r, "cookiepath", "starting with '/'")
+        },
+        test("rejects cookiepath with query string") {
+            for r <- load(validBase + ("security.cookiepath" -> "/admin?x=1")).exit
+            yield assertInvalidAt(r, "cookiepath", "no scheme, no query/fragment")
+        },
+        test("composed callbackUrl parses as an absolute URI") {
+            for cfg <- load(validBase)
+            yield
+                val uri = java.net.URI.create(cfg.callbackUrl)
+                assertTrue(
+                    uri.isAbsolute,
+                    uri.getHost == "localhost",
+                    uri.getPort == 8090,
+                    uri.getPath == "/auth/oidc/callback"
+                )
+        },
+        test("https urlBase composes correctly") {
+            for cfg <- load(
+                validBase + (
+                    "security.urlbase" -> "https://app.example.com",
+                    "security.callbackbase" -> "/auth/oidc"
+                )
+            )
+            yield assertTrue(
+                cfg.callbackUrl == "https://app.example.com/auth/oidc/callback"
+            )
+        },
+        test("missing sessionsecret produces MissingData error") {
+            for r <- load(validBase - "security.sessionsecret").exit
+            yield
+                val matched = r match
+                    case Exit.Failure(cause) =>
+                        cause.failures.exists:
+                            case Config.Error.MissingData(path, _) =>
+                                path.exists(_.toLowerCase.contains("sessionsecret"))
+                            case _ => false
+                    case _ => false
+                assertTrue(matched)
+        }
+    )
+end Pac4jSecurityConfigSpec


### PR DESCRIPTION
## Summary

iw-support 0.1.15's `Pac4jConfigFactory` composed the OIDC `redirect_uri` as
`urlBase + baseUri.toString + callbackBase + "/callback"`. When callers passed
`baseUri = BaseUri(urlBase)` (the natural-looking usage matching how `BaseUri` is
constructed everywhere else), `urlBase` was duplicated:

    http://localhost:8090http://localhost:8090/auth/oidc/callback

The same `baseUri.value.fold(\"/\")(_.toString)` was used for the session-cookie
`Path` attribute, producing `Path=http://localhost:8090` instead of a path.

Both bugs went unnoticed because no spec exercised the URL or cookie
composition — the existing pac4j tests only covered the `AuthenticationService`
plumbing. Surfaced during live verification of platform PLATFORM-210 Phase 2 (BFF
server with Auth0 OIDC); the Auth0 login dance failed immediately at the first
redirect with \"Callback URL mismatch.\"

## Changes

**API (breaking):**
- Dropped the `baseUri: BaseUri` parameter from `Pac4jConfigFactory` and
  `Pac4jHttpSecurity`. Removing it surfaces misuse at compile time so callers
  cannot silently produce malformed URLs. Downstream callers need a
  one-line update: drop the `baseUri` argument.

**`Pac4jSecurityConfig`:**
- New `cookiePath: Option[String]` field (default `Some(\"/\")`) replaces the
  misuse of `baseUri.toString` for the cookie `Path` attribute.
- New derived methods:
  - `callbackUrl: String = s\"\$urlBase\$callbackBase/callback\"` — composed once,
    used everywhere.
  - `resolvedCookiePath: String = cookiePath.getOrElse(\"/\")`.
- `mapOrFail` validation on the ZIO Config descriptor rejects malformed values
  with clear `Config.Error.InvalidData` at startup:
  - `urlbase` must be an absolute origin (no path/query/fragment, no trailing
    `/`)
  - `callbackbase` must be empty or path-only (leading `/`, no trailing `/`, no
    scheme)
  - `cookiepath` (when set) must be a path
  - composed `callbackUrl` must parse as an absolute URI with a host

  Anyone previously relying on a tolerated misconfiguration now fails loudly at
  boot with an actionable error message instead of silently producing broken
  URLs that Auth0 rejects.

**`Pac4jConfigFactory`:**
- Uses `cfg.callbackUrl` for the `Clients` registry — no more string surgery.
- Uses `cfg.resolvedCookiePath` for the session-store path.
- Fixed `secure` cookie flag to check `urlBase.startsWith(\"https://\")`. The
  previous check was on `callbackBase` which, after the contract change, is a
  path and never starts with a scheme — so the flag was always false.

**Tests:**
- New `Pac4jSecurityConfigSpec` with 15 cases locking down validation rules and
  composition: rejects trailing-slash `urlbase`, missing-slash `callbackbase`,
  scheme in `callbackbase`, bare `/`, invalid `cookiepath`; accepts empty
  `callbackbase`; verifies `callbackUrl` / `resolvedCookiePath` outputs and that
  the composed URL parses cleanly.
- Full `mill http.test` passes (~50 cases across 9 specs).

**Docs:**
- `HTTP_SERVER_GUIDE.md` Pac4j section rewritten with the new contract,
  per-field validation rules, composition formula, and an env-var mapping
  table. Marked the constructor change as a breaking change.

## Migration for downstream consumers

```diff
- new Pac4jConfigFactory[F](baseUri, pac4jConfig, dispatcher)
+ new Pac4jConfigFactory[F](pac4jConfig, dispatcher)

- new Pac4jHttpSecurity[F](baseUri, pac4jConfig, builtConfig, dispatcher)
+ new Pac4jHttpSecurity[F](pac4jConfig, builtConfig, dispatcher)
```

If `callbackBase` previously held a full URL or no leading slash, update it to
match the new contract; validation will surface the exact problem.

## Test plan

- [ ] Reviewer confirms breaking-change scope is acceptable for 0.1.17
- [ ] CI green
- [ ] Verified end-to-end on platform PLATFORM-210 with iw-support 0.1.17-SNAPSHOT:
  - `redirect_uri` clean single prefix
  - session cookie `Path=/`
  - Auth0 login dance reaches the IdP without rejection

Verified locally on iterative-works platform PLATFORM-210 against Auth0
\`fiftyforms.eu.auth0.com\` — `/health` unchanged, `/` 302 with clean
\`redirect_uri=http%3A%2F%2Flocalhost%3A8090%2Fauth%2Foidc%2Fcallback\`, session
cookie `Path=/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)